### PR TITLE
Minor updates to readme, adding py3.13 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          use_oidc: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          use_oidc: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
         channel-priority: [strict]
         envfile: [".github/environment.yml"]
         include:
-          - python-version: "3.12"
+          - python-version: "3.13"
             os: macos-latest
-          - python-version: "3.12"
+          - python-version: "3.13"
             os: windows-latest
-          - python-version: "3.12"
+          - python-version: "3.13"
             os: ubuntu-latest
             channel-priority: flexible
           - os: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
-.. image:: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml/badge.svg
-    :target: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml
+.. image:: https://anaconda.org/conda-forge/mir_eval/badges/version.svg 
+    :target: https://anaconda.org/conda-forge/mir_eval
 
 .. image:: https://img.shields.io/pypi/v/mir_eval.svg
     :target: https://pypi.python.org/pypi/mir_eval
+
+.. image:: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml
 
 .. image:: https://codecov.io/gh/mir-evaluation/mir_eval/graph/badge.svg?token=OzRL3aW7TX 
     :target: https://codecov.io/gh/mir-evaluation/mir_eval

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,15 @@
 .. image:: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml/badge.svg
     :target: https://github.com/mir-evaluation/mir_eval/actions/workflows/test.yml
+
+.. image:: https://img.shields.io/pypi/v/mir_eval.svg
+    :target: https://pypi.python.org/pypi/mir_eval
+
 .. image:: https://codecov.io/gh/mir-evaluation/mir_eval/graph/badge.svg?token=OzRL3aW7TX 
     :target: https://codecov.io/gh/mir-evaluation/mir_eval
+
+.. image:: https://img.shields.io/pypi/l/mir_eval.svg
+    :target: https://github.com/mir-evaluation/mir_eval/blob/main/LICENSE.txt
+
 
 mir_eval
 ========
@@ -13,6 +21,7 @@ Documentation, including installation and usage information: https://mir-evaluat
 Dependencies:
 
 * `Scipy/Numpy <http://www.scipy.org/>`_
+* `decorator <https://github.com/micheles/decorator>`_
 
 If you use mir_eval in a research project, please cite the following paper:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 
 [options]


### PR DESCRIPTION
This PR mirrors #405.  I'm reopening it under the main repo instead of a fork to test whether this is the cause of our codecov token failures.