### PR TITLE
implements #409: added strict monotonicity flag for hierarchical segmentation metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,10 @@ Thumbs.db
 # Vim
 *.swp
 
-# pycharm
+# IDEs
 .idea/*
+.vscode/*
+.vscode/*
 
 # docs
 docs/_build/*


### PR DESCRIPTION
added strict monotonicity flag for hierarchical segmentation metrics. Added new tests for coverage.

see #409 for details.

Soliciting feedback.