### PR TITLE
IO updates

### DIFF
--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -5,6 +5,7 @@ import numpy as np
 import re
 import warnings
 import scipy.io.wavfile
+from pathlib import Path
 
 from . import util
 from . import key
@@ -12,22 +13,22 @@ from . import tempo
 
 
 @contextlib.contextmanager
-def _open(file_or_str, **kwargs):
+def _open(file_or_path, **kwargs):
     """Either open a file handle, or use an existing file-like object.
 
-    This will behave as the `open` function if `file_or_str` is a string.
+    This will behave as the `open` function if `file_or_path` is a string or `pathlib.Path`.
 
-    If `file_or_str` has the `read` attribute, it will return `file_or_str`.
+    If `file_or_path` has the `read` attribute, it will return `file_or_path`.
 
     Otherwise, an `IOError` is raised.
     """
-    if hasattr(file_or_str, "read"):
-        yield file_or_str
-    elif isinstance(file_or_str, str):
-        with open(file_or_str, **kwargs) as file_desc:
+    if hasattr(file_or_path, "read"):
+        yield file_or_path
+    elif isinstance(file_or_path, (str, Path)):
+        with open(file_or_path, **kwargs) as file_desc:
             yield file_desc
     else:
-        raise IOError(f"Invalid file-or-str object: {file_or_str}")
+        raise IOError(f"Invalid file-or-path object: {file_or_path}")
 
 
 def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
@@ -43,7 +44,7 @@ def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     converters : list of functions
@@ -129,7 +130,7 @@ def load_events(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -169,7 +170,7 @@ def load_labeled_events(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -212,7 +213,7 @@ def load_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -255,7 +256,7 @@ def load_labeled_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -298,7 +299,7 @@ def load_time_series(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -339,7 +340,7 @@ def load_patterns(filename):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         The input file path containing the patterns of a given piece using the
         MIREX 2013 format.
 
@@ -406,12 +407,18 @@ def load_patterns(filename):
     return pattern_list
 
 
+@util.deprecated(version="0.8.1", version_removed="0.9.0")
 def load_wav(path, mono=True):
     """Load a .wav file as a numpy array using ``scipy.io.wavfile``.
 
+    .. warning:: This function is deprecatred in mir_eval 0.8.1
+        and will be removed in 0.9.0.
+        We recommend using a dedicated audio IO library such as
+        `soundfile` instead.
+
     Parameters
     ----------
-    path : str
+    path : str or `pathlib.Path`
         Path to a .wav file
     mono : bool
         If the provided .wav has more than one channel, it will be
@@ -450,7 +457,7 @@ def load_valued_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -497,7 +504,7 @@ def load_key(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -543,7 +550,7 @@ def load_tempo(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     delimiter : str
@@ -607,7 +614,7 @@ def load_ragged_time_series(
 
     Parameters
     ----------
-    filename : str
+    filename : str or `pathlib.Path`
         Path to the annotation file
 
     dtype : function

--- a/mir_eval/io.py
+++ b/mir_eval/io.py
@@ -5,7 +5,6 @@ import numpy as np
 import re
 import warnings
 import scipy.io.wavfile
-from pathlib import Path
 
 from . import util
 from . import key
@@ -16,19 +15,18 @@ from . import tempo
 def _open(file_or_path, **kwargs):
     """Either open a file handle, or use an existing file-like object.
 
-    This will behave as the `open` function if `file_or_path` is a string or `pathlib.Path`.
-
     If `file_or_path` has the `read` attribute, it will return `file_or_path`.
 
-    Otherwise, an `IOError` is raised.
+    Otherwise, it will attempt to open the file at the specified location.
     """
     if hasattr(file_or_path, "read"):
         yield file_or_path
-    elif isinstance(file_or_path, (str, Path)):
-        with open(file_or_path, **kwargs) as file_desc:
-            yield file_desc
     else:
-        raise IOError(f"Invalid file-or-path object: {file_or_path}")
+        try:
+            with open(file_or_path, **kwargs) as file_desc:
+                yield file_desc
+        except TypeError as exc:
+            raise IOError(f"Invalid file-or-path object: {file_or_path}") from exc
 
 
 def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
@@ -44,7 +42,7 @@ def load_delimited(filename, converters, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     converters : list of functions
@@ -130,7 +128,7 @@ def load_events(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -170,7 +168,7 @@ def load_labeled_events(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -213,7 +211,7 @@ def load_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -256,7 +254,7 @@ def load_labeled_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -299,7 +297,7 @@ def load_time_series(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -340,7 +338,7 @@ def load_patterns(filename):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         The input file path containing the patterns of a given piece using the
         MIREX 2013 format.
 
@@ -418,7 +416,7 @@ def load_wav(path, mono=True):
 
     Parameters
     ----------
-    path : str or `pathlib.Path`
+    path : str or `os.Pathlike`
         Path to a .wav file
     mono : bool
         If the provided .wav has more than one channel, it will be
@@ -457,7 +455,7 @@ def load_valued_intervals(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -504,7 +502,7 @@ def load_key(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -550,7 +548,7 @@ def load_tempo(filename, delimiter=r"\s+", comment="#"):
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     delimiter : str
@@ -614,7 +612,7 @@ def load_ragged_time_series(
 
     Parameters
     ----------
-    filename : str or `pathlib.Path`
+    filename : str or `os.Pathlike`
         Path to the annotation file
 
     dtype : function

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -69,13 +69,15 @@ def test_load_delimited_nocomment():
         assert np.allclose(col2, [20, 50])
 
 
-@pytest.mark.parametrize("file_or_path", ["data/beat/ref01.txt",
-                         pathlib.Path("data/beat/ref01.txt")])
+@pytest.mark.parametrize(
+    "file_or_path", ["data/beat/ref01.txt", pathlib.Path("data/beat/ref01.txt")]
+)
 def test_load_delimited_file_or_path(file_or_path):
     # Tests the load_delimited routine with either a string or a
-# pathlib.Path object as the first argument
+    # pathlib.Path object as the first argument
     data = mir_eval.io.load_delimited(file_or_path, [float])
     assert len(data) == 635
+
 
 def test_load_events():
     # Test for a warning when invalid events are supplied

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -4,6 +4,7 @@ import numpy as np
 import json
 import mir_eval
 import warnings
+import pathlib
 import tempfile
 import pytest
 
@@ -67,6 +68,14 @@ def test_load_delimited_nocomment():
         assert np.allclose(col1, [10, 30])
         assert np.allclose(col2, [20, 50])
 
+
+@pytest.mark.parametrize("file_or_path", ["data/beat/ref01.txt",
+                         pathlib.Path("data/beat/ref01.txt")])
+def test_load_delimited_file_or_path(file_or_path):
+    # Tests the load_delimited routine with either a string or a
+# pathlib.Path object as the first argument
+    data = mir_eval.io.load_delimited(file_or_path, [float])
+    assert len(data) == 635
 
 def test_load_events():
     # Test for a warning when invalid events are supplied


### PR DESCRIPTION
Fixes #415 
Fixes #413 

---

This PR adds support for `pathlib.Path` objects in all `mir_eval.io` loaders.  (Easy fix, just adding a case to the `_open` context manager's type check.)

I've added one unit test that hits `load_delimited` with either string or Path input.  I think this is sufficient since: A) almost all other loaders run through `load_delimited`, and B) those that don't use the same `_open` context manager anyway.

Since I was in .io anyway, I added a deprecation on `load_wav`.

Assuming this passes CI, I think it should be good to merge.