### PR TITLE
More sonification fixes

### DIFF
--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -116,12 +116,12 @@ def time_frequency(
 
     # Default value for length
     if length is None:
-        length = int(times[-1, 1] * fs)
+        length = int(np.max(times) * fs)
 
     last_time_in_secs = float(length) / fs
 
     if time_converted and times.shape[0] != gram.shape[1]:
-        times = np.vstack((times, [times[-1, 1], last_time_in_secs]))
+        times = np.vstack((times, [np.max(times), last_time_in_secs]))
 
     if times.shape[0] != gram.shape[1]:
         raise ValueError(

--- a/mir_eval/sonify.py
+++ b/mir_eval/sonify.py
@@ -183,15 +183,14 @@ def time_frequency(
             bounds_error=False,
             fill_value=(gram[:, 0], gram[:, -1]),
         )
+        signal = interpolator(np.arange(length))
     else:
         # NOTE: This is a special case where there is only one time interval.
         # scipy 1.10 and above handle this case directly with the interp1d above,
         # but older scipy's do not. This is a workaround for that.
         #
         # In the 0.9 release, we can bump the minimum scipy to 1.10 and remove this
-        interpolator = _const_interpolator(gram[:, 0])
-
-    signal = interpolator(np.arange(length))
+        signal = np.tile(gram[:, 0], (1, length))
 
     for n, frequency in enumerate(frequencies):
         # Get a waveform of length samples at this frequency
@@ -211,17 +210,6 @@ def time_frequency(
         output /= norm
 
     return output
-
-
-def _const_interpolator(value):
-    """Return a function that returns `value`
-    no matter the input.
-    """
-
-    def __interpolator(x):
-        return value
-
-    return __interpolator
 
 
 def _fast_synthesize(frequency, n_dec, fs, function, length):

--- a/tests/test_sonify.py
+++ b/tests/test_sonify.py
@@ -50,6 +50,28 @@ def test_time_frequency(fs):
     assert len(signal) == 5 * fs
 
 
+def test_time_frequency_const():
+
+    # Sonify with a single interval to hit the const interpolator
+    s1 = mir_eval.sonify.time_frequency(
+        np.ones((1, 1)),
+        np.array([60]),
+        np.array([[0, 1]]),
+        8000,
+    )
+    # Sonify with two tiem intervals to hit the regular interpolator
+    # but the second frequency will have no energy, so it doesn't
+    # change the resulting signal
+    s2 = mir_eval.sonify.time_frequency(
+        np.array([[1, 1], [0, 0]]),
+        np.array([60, 90]),
+        np.array([[0, 1], [0, 1]]),
+        8000,
+    )
+
+    assert np.allclose(s1, s2)
+
+
 def test_time_frequency_offset():
     fs = 8000
     # Length is 3 seconds, first interval starts at 5.


### PR DESCRIPTION
This PR fixes yet another bug in time-frequency sonification that occurs when sonifying a single frequency over a single time step.  The problem was that the const interpolator was not properly respecting the dimension of the interpolation grid.

I've added a test case to cover this, though the problem will go away in 0.9 when we bump up the minimum scipy version and remove the need for the const interpolator branch.